### PR TITLE
Improve tweet posting and feed rendering

### DIFF
--- a/src/Feed.js
+++ b/src/Feed.js
@@ -9,9 +9,13 @@ function Feed() {
   const [posts, setPosts] = useState([]);
 
   useEffect(() => {
-    db.collection("posts").onSnapshot((snapshot) =>
-      setPosts(snapshot.docs.map((doc) => doc.data()))
+    const unsubscribe = db.collection("posts").onSnapshot((snapshot) =>
+      setPosts(
+        snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }))
+      )
     );
+
+    return () => unsubscribe();
   }, []);
 
   return (
@@ -25,7 +29,7 @@ function Feed() {
       <FlipMove>
         {posts.map((post) => (
           <Post
-            key={post.text}
+            key={post.id || post.text}
             displayName={post.displayName}
             username={post.username}
             verified={post.verified}

--- a/src/TweetBox.js
+++ b/src/TweetBox.js
@@ -6,25 +6,20 @@ import db from "./firebase";
 function TweetBox() {
   const [tweetMessage, setTweetMessage] = useState("");
   const [tweetImage, setTweetImage] = useState("");
-  const [localTweets, setLocalTweets] = useState([]); // Add local state for temporary tweets
-
   const sendTweet = (e) => {
     e.preventDefault();
-    // Add tweet to local state instead of backend
-    if (tweetMessage.trim() !== "") {
-      setLocalTweets([
-        ...localTweets,
-        {
-          displayName: "Rafeh Qazi",
-          username: "cleverqazi",
-          verified: true,
-          text: tweetMessage,
-          image: tweetImage,
-          avatar:
-            "https://kajabi-storefronts-production.global.ssl.fastly.net/kajabi-storefronts-production/themes/284832/settings_images/rLlCifhXRJiT0RoN2FjK_Logo_roundbackground_black.png",
-        },
-      ]);
-    }
+    if (tweetMessage.trim() === "") return;
+
+    db.collection("posts").add({
+      displayName: "Rafeh Qazi",
+      username: "cleverqazi",
+      verified: true,
+      text: tweetMessage,
+      image: tweetImage,
+      avatar:
+        "https://kajabi-storefronts-production.global.ssl.fastly.net/kajabi-storefronts-production/themes/284832/settings_images/rLlCifhXRJiT0RoN2FjK_Logo_roundbackground_black.png",
+    });
+
     setTweetMessage("");
     setTweetImage("");
   };
@@ -57,43 +52,6 @@ function TweetBox() {
           Tweet
         </Button>
       </form>
-      {/* Show local tweets below input */}
-      <div style={{ marginTop: 20 }}>
-        {localTweets.map((tweet, idx) => (
-          <div
-            key={idx}
-            style={{
-              border: "1px solid #e6ecf0",
-              borderRadius: 10,
-              padding: 10,
-              marginBottom: 10,
-              background: "#fff",
-            }}
-          >
-            <div style={{ display: "flex", alignItems: "center" }}>
-              <Avatar src={tweet.avatar} style={{ marginRight: 10 }} />
-              <div>
-                <strong>{tweet.displayName}</strong> @{tweet.username}{" "}
-                {tweet.verified && (
-                  <span style={{ color: "#1da1f2" }}>✔</span>
-                )}
-              </div>
-            </div>
-            <div style={{ marginTop: 10 }}>{tweet.text}</div>
-            {tweet.image && (
-              <img
-                src={tweet.image}
-                alt="tweet"
-                style={{
-                  marginTop: 10,
-                  maxWidth: "100%",
-                  borderRadius: 10,
-                }}
-              />
-            )}
-          </div>
-        ))}
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- store Firestore document id and use as key when displaying posts
- post tweets directly to Firestore and remove local-only tweet list

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6867529eb0b0832d8b1ca68f2a22b68f