### PR TITLE
Improve Feed and TweetBox

### DIFF
--- a/src/Feed.js
+++ b/src/Feed.js
@@ -9,9 +9,13 @@ function Feed() {
   const [posts, setPosts] = useState([]);
 
   useEffect(() => {
-    db.collection("posts").onSnapshot((snapshot) =>
-      setPosts(snapshot.docs.map((doc) => doc.data()))
+    const unsubscribe = db.collection("posts").onSnapshot((snapshot) =>
+      setPosts(
+        snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }))
+      )
     );
+
+    return unsubscribe;
   }, []);
 
   return (
@@ -23,17 +27,19 @@ function Feed() {
       <TweetBox />
 
       <FlipMove>
-        {posts.map((post) => (
-          <Post
-            key={post.text}
-            displayName={post.displayName}
-            username={post.username}
-            verified={post.verified}
-            text={post.text}
-            avatar={post.avatar}
-            image={post.image}
-          />
-        ))}
+        {posts.map(
+          ({ id, displayName, username, verified, text, avatar, image }) => (
+            <Post
+              key={id}
+              displayName={displayName}
+              username={username}
+              verified={verified}
+              text={text}
+              avatar={avatar}
+              image={image}
+            />
+          )
+        )}
       </FlipMove>
     </div>
   );

--- a/src/TweetBox.js
+++ b/src/TweetBox.js
@@ -31,7 +31,7 @@ function TweetBox() {
 
   return (
     <div className="tweetBox">
-      <form>
+      <form onSubmit={sendTweet}>
         <div className="tweetBox__input">
           <Avatar src="https://kajabi-storefronts-production.global.ssl.fastly.net/kajabi-storefronts-production/themes/284832/settings_images/rLlCifhXRJiT0RoN2FjK_Logo_roundbackground_black.png" />
           <input
@@ -49,11 +49,7 @@ function TweetBox() {
           type="text"
         />
 
-        <Button
-          onClick={sendTweet}
-          type="submit"
-          className="tweetBox__tweetButton"
-        >
+        <Button type="submit" className="tweetBox__tweetButton">
           Tweet
         </Button>
       </form>


### PR DESCRIPTION
## Summary
- clean up Firestore subscription and use document IDs for keys
- allow TweetBox form submission with the Enter key

## Testing
- `npm install`
- `npm test --silent --yes`

------
https://chatgpt.com/codex/tasks/task_e_6867529eb0b0832d8b1ca68f2a22b68f