### PR TITLE
Update feed key handling and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,68 +1,31 @@
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+# Twitter Clone
+
+This project recreates a simplified Twitter interface using **React** and **Firebase**. It was originally bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm start
+   ```
+   The app will be available at [http://localhost:3000](http://localhost:3000).
+3. Run tests once in CI mode:
+   ```bash
+   CI=true npm test
+   ```
+
+The Firebase configuration in `src/firebase.js` points to a demo project so you can see sample tweets without additional setup.
 
 ## Available Scripts
 
-In the project directory, you can run:
+The following commands are provided by Create React App:
+- `npm start` – start the dev server
+- `npm test` – run tests in watch mode
+- `npm run build` – create a production build
+- `npm run eject` – copy configuration files locally (not reversible)
 
-### `npm start`
-
-Runs the app in the development mode.<br />
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
-
-The page will reload if you make edits.<br />
-You will also see any lint errors in the console.
-
-### `npm test`
-
-Launches the test runner in the interactive watch mode.<br />
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
-
-### `npm run build`
-
-Builds the app for production to the `build` folder.<br />
-It correctly bundles React in production mode and optimizes the build for the best performance.
-
-The build is minified and the filenames include the hashes.<br />
-Your app is ready to be deployed!
-
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
-
-### `npm run eject`
-
-**Note: this is a one-way operation. Once you `eject`, you can’t go back!**
-
-If you aren’t satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
-
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
-
-You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
-
-## Learn More
-
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
-
-To learn React, check out the [React documentation](https://reactjs.org/).
-
-### Code Splitting
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/code-splitting
-
-### Analyzing the Bundle Size
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size
-
-### Making a Progressive Web App
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app
-
-### Advanced Configuration
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/advanced-configuration
-
-### Deployment
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/deployment
-
-### `npm run build` fails to minify
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify
+For more details, see the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).

--- a/src/Feed.js
+++ b/src/Feed.js
@@ -9,8 +9,8 @@ function Feed() {
   const [posts, setPosts] = useState([]);
 
   useEffect(() => {
-    db.collection("posts").onSnapshot((snapshot) =>
-      setPosts(snapshot.docs.map((doc) => doc.data()))
+    return db.collection("posts").onSnapshot((snapshot) =>
+      setPosts(snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() })))
     );
   }, []);
 
@@ -23,9 +23,9 @@ function Feed() {
       <TweetBox />
 
       <FlipMove>
-        {posts.map((post) => (
-          <Post
-            key={post.text}
+          {posts.map((post) => (
+            <Post
+              key={post.id || post.text}
             displayName={post.displayName}
             username={post.username}
             verified={post.verified}

--- a/src/Post.js
+++ b/src/Post.js
@@ -29,7 +29,7 @@ const Post = forwardRef(
               <p>{text}</p>
             </div>
           </div>
-          <img src={image} alt="" />
+          <img src={image} alt={`Tweet image from ${displayName}`} />
           <div className="post__footer">
             <ChatBubbleOutlineIcon fontSize="small" />
             <RepeatIcon fontSize="small" />


### PR DESCRIPTION
## Summary
- clarify setup instructions in README
- store document IDs in the feed and use them as keys
- add alt text for post images

## Testing
- `CI=true npm test --silent` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6867529eb0b0832d8b1ca68f2a22b68f